### PR TITLE
This commit adds a ping method to connection

### DIFF
--- a/src/clientOperations/pingOperation.js
+++ b/src/clientOperations/pingOperation.js
@@ -1,0 +1,30 @@
+var util = require('util');
+var uuid = require('uuid');
+
+var ClientMessage = require('../messages/clientMessage');
+var TcpCommand = require('../systemData/tcpCommand');
+var OperationBase = require('../clientOperations/operationBase');
+
+function PingOperation(log, cb, requireMaster, userCredentials) {
+  OperationBase.call(this, log, cb, TcpCommand.Ping, TcpCommand.Pong, userCredentials);
+  this._responseType = ClientMessage.Pong;
+  this._cb = cb;
+
+  this._requireMaster = requireMaster;
+}
+util.inherits(PingOperation, OperationBase);
+
+PingOperation.prototype._createRequestDto = function() {
+  return new ClientMessage.Ping();
+}
+
+PingOperation.prototype._inspectResponse = function(r) {
+  this._succeed();
+  return new InspectionResult(InspectionDecision.EndOperation, "Success");
+}
+
+PingOperation.prototype._transformResponse = function(r) {
+  return {};
+}
+
+module.exports = PingOperation;

--- a/src/eventStoreNodeConnection.js
+++ b/src/eventStoreNodeConnection.js
@@ -6,6 +6,7 @@ var ensure = require('./common/utils/ensure');
 var messages = require('./core/messages');
 var EventStoreConnectionLogicHandler = require('./core/eventStoreConnectionLogicHandler');
 
+var PingOperation = require('./clientOperations/pingOperation');
 var DeleteStreamOperation = require('./clientOperations/deleteStreamOperation');
 var AppendToStreamOperation = require('./clientOperations/appendToStreamOperation');
 var StartTransactionOperation = require('./clientOperations/startTransactionOperation');
@@ -693,6 +694,17 @@ EventStoreNodeConnection.prototype.getStreamMetadataRaw = function(stream, userC
 EventStoreNodeConnection.prototype.setSystemSettings = function() {
   //TODO: set system settings
   throw new Error("Not implemented.");
+};
+
+EventStoreNodeConnection.prototype.ping = function () {
+  var self = this;
+  return new Promise(function(resolve, reject) {
+    function cb(err, result) {
+      if (err) return reject(err);
+      resolve(result);
+    }
+    self._enqueueOperation(new PingOperation(self._settings.log, cb, self._settings.requireMaster, self._settings.userCredentials));
+  });
 };
 
 EventStoreNodeConnection.prototype._enqueueOperation = function(operation) {

--- a/src/messages/messages.js
+++ b/src/messages/messages.js
@@ -834,8 +834,8 @@ $root.EventStore = (function() {
                             break;
                         }
                     }
-                    //if (!message.hasOwnProperty("event"))
-                        //throw $util.ProtocolError("missing required 'event'", { instance: message });
+//                    if (!message.hasOwnProperty("event"))
+//                        throw $util.ProtocolError("missing required 'event'", { instance: message });
                     return message;
                 };
 
@@ -9533,6 +9533,304 @@ $root.EventStore = (function() {
                 };
 
                 return UnsubscribeFromStream;
+            })();
+
+            Messages.Ping = (function() {
+
+                /**
+                 * Properties of a Ping.
+                 * @typedef EventStore.Client.Messages.Ping$Properties
+                 * @type {Object}
+                 */
+
+                /**
+                 * Constructs a new Ping.
+                 * @exports EventStore.Client.Messages.Ping
+                 * @constructor
+                 * @param {EventStore.Client.Messages.Ping$Properties=} [properties] Properties to set
+                 */
+                function Ping(properties) {
+                    if (properties)
+                        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                            if (properties[keys[i]] != null)
+                                this[keys[i]] = properties[keys[i]];
+                }
+
+                /**
+                 * Creates a new Ping instance using the specified properties.
+                 * @param {EventStore.Client.Messages.Ping$Properties=} [properties] Properties to set
+                 * @returns {EventStore.Client.Messages.Ping} Ping instance
+                 */
+                Ping.create = function create(properties) {
+                    return new Ping(properties);
+                };
+
+                /**
+                 * Encodes the specified Ping message. Does not implicitly {@link EventStore.Client.Messages.Ping.verify|verify} messages.
+                 * @param {EventStore.Client.Messages.Ping$Properties} message Ping message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                Ping.encode = function encode(message, writer) {
+                    if (!writer)
+                        writer = $Writer.create();
+                    return writer;
+                };
+
+                /**
+                 * Encodes the specified Ping message, length delimited. Does not implicitly {@link EventStore.Client.Messages.Ping.verify|verify} messages.
+                 * @param {EventStore.Client.Messages.Ping$Properties} message Ping message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                Ping.encodeDelimited = function encodeDelimited(message, writer) {
+                    return this.encode(message, writer).ldelim();
+                };
+
+                /**
+                 * Decodes a Ping message from the specified reader or buffer.
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @param {number} [length] Message length if known beforehand
+                 * @returns {EventStore.Client.Messages.Ping} Ping
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                Ping.decode = function decode(reader, length) {
+                    if (!(reader instanceof $Reader))
+                        reader = $Reader.create(reader);
+                    var end = length === undefined ? reader.len : reader.pos + length, message = new $root.EventStore.Client.Messages.Ping();
+                    while (reader.pos < end) {
+                        var tag = reader.uint32();
+                        switch (tag >>> 3) {
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                        }
+                    }
+                    return message;
+                };
+
+                /**
+                 * Decodes a Ping message from the specified reader or buffer, length delimited.
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @returns {EventStore.Client.Messages.Ping} Ping
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                Ping.decodeDelimited = function decodeDelimited(reader) {
+                    if (!(reader instanceof $Reader))
+                        reader = $Reader(reader);
+                    return this.decode(reader, reader.uint32());
+                };
+
+                /**
+                 * Verifies a Ping message.
+                 * @param {Object.<string,*>} message Plain object to verify
+                 * @returns {?string} `null` if valid, otherwise the reason why it is not
+                 */
+                Ping.verify = function verify(message) {
+                    if (typeof message !== "object" || message === null)
+                        return "object expected";
+                    return null;
+                };
+
+                /**
+                 * Creates a Ping message from a plain object. Also converts values to their respective internal types.
+                 * @param {Object.<string,*>} object Plain object
+                 * @returns {EventStore.Client.Messages.Ping} Ping
+                 */
+                Ping.fromObject = function fromObject(object) {
+                    if (object instanceof $root.EventStore.Client.Messages.Ping)
+                        return object;
+                    return new $root.EventStore.Client.Messages.Ping();
+                };
+
+                /**
+                 * Creates a Ping message from a plain object. Also converts values to their respective internal types.
+                 * This is an alias of {@link EventStore.Client.Messages.Ping.fromObject}.
+                 * @function
+                 * @param {Object.<string,*>} object Plain object
+                 * @returns {EventStore.Client.Messages.Ping} Ping
+                 */
+                Ping.from = Ping.fromObject;
+
+                /**
+                 * Creates a plain object from a Ping message. Also converts values to other types if specified.
+                 * @param {EventStore.Client.Messages.Ping} message Ping
+                 * @param {$protobuf.ConversionOptions} [options] Conversion options
+                 * @returns {Object.<string,*>} Plain object
+                 */
+                Ping.toObject = function toObject() {
+                    return {};
+                };
+
+                /**
+                 * Creates a plain object from this Ping message. Also converts values to other types if specified.
+                 * @param {$protobuf.ConversionOptions} [options] Conversion options
+                 * @returns {Object.<string,*>} Plain object
+                 */
+                Ping.prototype.toObject = function toObject(options) {
+                    return this.constructor.toObject(this, options);
+                };
+
+                /**
+                 * Converts this Ping to JSON.
+                 * @returns {Object.<string,*>} JSON object
+                 */
+                Ping.prototype.toJSON = function toJSON() {
+                    return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                };
+
+                return Ping;
+            })();
+
+            Messages.Pong = (function() {
+
+                /**
+                 * Properties of a Pong.
+                 * @typedef EventStore.Client.Messages.Pong$Properties
+                 * @type {Object}
+                 */
+
+                /**
+                 * Constructs a new Pong.
+                 * @exports EventStore.Client.Messages.Pong
+                 * @constructor
+                 * @param {EventStore.Client.Messages.Pong$Properties=} [properties] Properties to set
+                 */
+                function Pong(properties) {
+                    if (properties)
+                        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                            if (properties[keys[i]] != null)
+                                this[keys[i]] = properties[keys[i]];
+                }
+
+                /**
+                 * Creates a new Pong instance using the specified properties.
+                 * @param {EventStore.Client.Messages.Pong$Properties=} [properties] Properties to set
+                 * @returns {EventStore.Client.Messages.Pong} Pong instance
+                 */
+                Pong.create = function create(properties) {
+                    return new Pong(properties);
+                };
+
+                /**
+                 * Encodes the specified Pong message. Does not implicitly {@link EventStore.Client.Messages.Pong.verify|verify} messages.
+                 * @param {EventStore.Client.Messages.Pong$Properties} message Pong message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                Pong.encode = function encode(message, writer) {
+                    if (!writer)
+                        writer = $Writer.create();
+                    return writer;
+                };
+
+                /**
+                 * Encodes the specified Pong message, length delimited. Does not implicitly {@link EventStore.Client.Messages.Pong.verify|verify} messages.
+                 * @param {EventStore.Client.Messages.Pong$Properties} message Pong message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                Pong.encodeDelimited = function encodeDelimited(message, writer) {
+                    return this.encode(message, writer).ldelim();
+                };
+
+                /**
+                 * Decodes a Pong message from the specified reader or buffer.
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @param {number} [length] Message length if known beforehand
+                 * @returns {EventStore.Client.Messages.Pong} Pong
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                Pong.decode = function decode(reader, length) {
+                    if (!(reader instanceof $Reader))
+                        reader = $Reader.create(reader);
+                    var end = length === undefined ? reader.len : reader.pos + length, message = new $root.EventStore.Client.Messages.Pong();
+                    while (reader.pos < end) {
+                        var tag = reader.uint32();
+                        switch (tag >>> 3) {
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                        }
+                    }
+                    return message;
+                };
+
+                /**
+                 * Decodes a Pong message from the specified reader or buffer, length delimited.
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @returns {EventStore.Client.Messages.Pong} Pong
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                Pong.decodeDelimited = function decodeDelimited(reader) {
+                    if (!(reader instanceof $Reader))
+                        reader = $Reader(reader);
+                    return this.decode(reader, reader.uint32());
+                };
+
+                /**
+                 * Verifies a Pong message.
+                 * @param {Object.<string,*>} message Plain object to verify
+                 * @returns {?string} `null` if valid, otherwise the reason why it is not
+                 */
+                Pong.verify = function verify(message) {
+                    if (typeof message !== "object" || message === null)
+                        return "object expected";
+                    return null;
+                };
+
+                /**
+                 * Creates a Pong message from a plain object. Also converts values to their respective internal types.
+                 * @param {Object.<string,*>} object Plain object
+                 * @returns {EventStore.Client.Messages.Pong} Pong
+                 */
+                Pong.fromObject = function fromObject(object) {
+                    if (object instanceof $root.EventStore.Client.Messages.Pong)
+                        return object;
+                    return new $root.EventStore.Client.Messages.Pong();
+                };
+
+                /**
+                 * Creates a Pong message from a plain object. Also converts values to their respective internal types.
+                 * This is an alias of {@link EventStore.Client.Messages.Pong.fromObject}.
+                 * @function
+                 * @param {Object.<string,*>} object Plain object
+                 * @returns {EventStore.Client.Messages.Pong} Pong
+                 */
+                Pong.from = Pong.fromObject;
+
+                /**
+                 * Creates a plain object from a Pong message. Also converts values to other types if specified.
+                 * @param {EventStore.Client.Messages.Pong} message Pong
+                 * @param {$protobuf.ConversionOptions} [options] Conversion options
+                 * @returns {Object.<string,*>} Plain object
+                 */
+                Pong.toObject = function toObject() {
+                    return {};
+                };
+
+                /**
+                 * Creates a plain object from this Pong message. Also converts values to other types if specified.
+                 * @param {$protobuf.ConversionOptions} [options] Conversion options
+                 * @returns {Object.<string,*>} Plain object
+                 */
+                Pong.prototype.toObject = function toObject(options) {
+                    return this.constructor.toObject(this, options);
+                };
+
+                /**
+                 * Converts this Pong to JSON.
+                 * @returns {Object.<string,*>} JSON object
+                 */
+                Pong.prototype.toJSON = function toJSON() {
+                    return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                };
+
+                return Pong;
             })();
 
             Messages.SubscriptionDropped = (function() {

--- a/src/messages/messages.proto
+++ b/src/messages/messages.proto
@@ -325,6 +325,13 @@ message StreamEventAppeared {
 message UnsubscribeFromStream {
 }
 
+message Ping {
+}
+
+message Pong {
+}
+
+
 message SubscriptionDropped {
 
 	enum SubscriptionDropReason {

--- a/test/ping_test.js
+++ b/test/ping_test.js
@@ -1,0 +1,15 @@
+module.exports = {
+
+  'Test Send Ping': function (test) {
+    this.conn.ping()
+      .then(function () {
+        test.done();
+      })
+      .catch(function(err) {
+        test.done(err)
+      });
+  }
+};
+
+require('./common/base_test').init(module.exports);
+


### PR DESCRIPTION
We use the Ping method for health checks on event consumers, and it's
useful as a testing tool. I'm not sure if it's worth keeping the
Ping/Pong types, or if it would be better to have a simple EmptyMessage
and EmptyResult.

In particular, we currently return the empty object literal {} from transformResult which makes me sad.

Happy to throw this away and change approach if you have a better suggestion.